### PR TITLE
Fix environment description typo

### DIFF
--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -2,7 +2,7 @@ targetScope = 'subscription'
 
 @minLength(1)
 @maxLength(20)
-@description('Name of the the environment which is used to generate a short unique hash used in all resources.')
+@description('Name of the environment which is used to generate a short unique hash used in all resources.')
 param environmentName string
 var abbrs = loadJsonContent('./abbreviations.json')
 

--- a/infra/main.json
+++ b/infra/main.json
@@ -13,9 +13,9 @@
       "type": "string",
       "minLength": 1,
       "maxLength": 20,
-      "metadata": {
-        "description": "Name of the the environment which is used to generate a short unique hash used in all resources."
-      }
+        "metadata": {
+          "description": "Name of the environment which is used to generate a short unique hash used in all resources."
+        }
     },
     "resourceToken": {
       "type": "string",


### PR DESCRIPTION
## Summary
- fix double word typo in environment parameter description

## Testing
- `pre-commit` *(fails: `az: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_684dc9daa0648320b69ff6d1c01093af