### PR TITLE
Fix cosmosdb message ordering

### DIFF
--- a/code/backend/batch/utilities/chat_history/cosmosdb.py
+++ b/code/backend/batch/utilities/chat_history/cosmosdb.py
@@ -195,7 +195,7 @@ class CosmosConversationClient(DatabaseClientBase):
             {"name": "@conversationId", "value": conversation_id},
             {"name": "@userId", "value": user_id},
         ]
-        query = "SELECT * FROM c WHERE c.conversationId = @conversationId AND c.type='message' AND c.userId = @userId ORDER BY c.timestamp ASC"
+        query = "SELECT * FROM c WHERE c.conversationId = @conversationId AND c.type='message' AND c.userId = @userId ORDER BY c.createdAt ASC"
         messages = []
         async for item in self.container_client.query_items(
             query=query, parameters=parameters


### PR DESCRIPTION
## Summary
- use `createdAt` when ordering chat messages from Cosmos DB
- test Cosmos DB message retrieval order by `createdAt`

## Testing
- `pytest code/tests/chat_history/test_cosmosdb.py -q`

------
https://chatgpt.com/codex/tasks/task_e_684dc9e03628832086b6da65776d0635